### PR TITLE
Add a (hacky) script to scale Mermaid charts with the viewport size

### DIFF
--- a/src/_includes/layout.liquid
+++ b/src/_includes/layout.liquid
@@ -40,5 +40,32 @@
     });
   </script>
   {% mermaid_js %}
+  <script>
+    (function () {
+      function fitViewBox(svg) {
+        if (!svg || svg.dataset.viewboxFitted) return false;
+        const bb = svg.getBBox();
+        if (!bb.width || !bb.height) return false;
+        const pad = 16;
+        svg.setAttribute("viewBox", `${bb.x - pad} ${bb.y - pad} ${bb.width + pad * 2} ${bb.height + pad * 2}`);
+        svg.style.maxWidth = `${bb.width + pad * 2}px`;
+        svg.dataset.viewboxFitted = "1";
+        return true;
+      }
+      function sweep() {
+        let pending = false;
+        document.querySelectorAll('.mermaid[data-processed="true"] svg').forEach((svg) => {
+          if (!fitViewBox(svg)) pending = true;
+        });
+        if (pending) setTimeout(sweep, 100);
+      }
+      new MutationObserver(sweep).observe(document.body, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["data-processed"],
+      });
+      sweep();
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Mermaid 11's flowchart layout emits an oversized `viewBox` (~3× the actual content bbox) for some diagrams, leaving the rendered container mostly empty on wide viewports — see the governance chart in [src/blog/about-ecma-1.md](src/blog/about-ecma-1.md).
- Adds a small post-render script in `src/_includes/layout.liquid` that recomputes each mermaid SVG's `viewBox` and `max-width` from `getBBox()` once it's laid out. Polls every 100ms when `getBBox()` returns 0,0 because mermaid sets `data-processed="true"` before layout completes.
- No CSS changes, no plugin config changes, no edits to the diagram source.

## Test plan
- [x] Verified at 2560×1392: container shrinks from 1047px tall to 700px, diagram fills the box.
- [x] Verified at 375×812 (mobile): diagram scales down responsively (307×257) and stays legible.
- [x] Verified in dark mode at 2560×1392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)