### PR TITLE
Theme switcher, footer feedback link, and mobile/footer layout polish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "eleventy",
       "runtimeExecutable": "cmd",
-      "runtimeArgs": ["/c", "npm", "run", "dev"],
+      "runtimeArgs": ["/c", "pnpm", "dev"],
       "port": 8080
     }
   ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "build:css": "mkdir -p _site/css && lightningcss --minify --bundle src/css/main.css -o _site/css/main.css",
+    "build:css": "lightningcss --minify --bundle src/css/main.css -o _site/css/main.css",
     "build": "eleventy && pnpm run build:css",
     "dev": "eleventy --serve",
     "lint": "markuplint \"src/**/*.{html,liquid,md}\"",

--- a/src/_includes/layout.liquid
+++ b/src/_includes/layout.liquid
@@ -14,6 +14,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
   <script data-goatcounter="https://ryzokuken.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem("theme");
+        if (t === "light" || t === "dark") {
+          document.documentElement.setAttribute("data-theme", t);
+        }
+      } catch (e) {}
+    })();
+  </script>
   <link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
@@ -32,13 +42,46 @@
     {{ content }}
   </main>
   <footer id="footer">
-    <p>Made with ❤️ by <a href="https://mastodon.social/@ryzokuken">Ryzokuken</a> using <a href="https://www.11ty.dev/">11ty</a></p>
+    <div id="theme-switcher" role="group" aria-label="Color theme">
+      <span class="theme-switcher-label">theme:</span>
+      <button type="button" data-theme-set="auto">auto</button>
+      <button type="button" data-theme-set="light">light</button>
+      <button type="button" data-theme-set="dark">dark</button>
+    </div>
+    <p>Made with ❤️ by <a href="https://mastodon.social/@ryzokuken">Ryzokuken</a> using <a href="https://www.11ty.dev/">11ty</a> · <a href="https://github.com/ryzokuken/ryzokuken.github.io/issues/new">Suggest a change</a></p>
   </footer>
   <script src="https://unpkg.com/@twemoji/api@15.1.0/dist/twemoji.min.js" integrity="sha384-o28+zJO3/45GHIy+9TFKGaYnbt0KQcFRzyBrb0WSSrz7bPGwGI1d64worBiXPgXw" crossorigin="anonymous"></script>
   <script>
     document.addEventListener("DOMContentLoaded", function() {
       twemoji.parse(document.body, { folder: 'svg', ext: '.svg' });
     });
+  </script>
+  <script>
+    (function () {
+      var key = "theme";
+      var buttons = document.querySelectorAll("#theme-switcher button[data-theme-set]");
+      if (!buttons.length) return;
+      var stored;
+      try { stored = localStorage.getItem(key); } catch (e) {}
+      var current = (stored === "light" || stored === "dark") ? stored : "auto";
+      function apply(value) {
+        current = value;
+        if (value === "auto") {
+          document.documentElement.removeAttribute("data-theme");
+          try { localStorage.removeItem(key); } catch (e) {}
+        } else {
+          document.documentElement.setAttribute("data-theme", value);
+          try { localStorage.setItem(key, value); } catch (e) {}
+        }
+        buttons.forEach(function (b) {
+          b.setAttribute("aria-pressed", b.dataset.themeSet === current ? "true" : "false");
+        });
+      }
+      buttons.forEach(function (b) {
+        b.setAttribute("aria-pressed", b.dataset.themeSet === current ? "true" : "false");
+        b.addEventListener("click", function () { apply(b.dataset.themeSet); });
+      });
+    })();
   </script>
   {% mermaid_js %}
   <script>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -863,6 +863,7 @@ img {
   #navbar li {
     display: flex;
     justify-content: center;
+    min-width: 0;
   }
 
   #navbar a {
@@ -876,5 +877,22 @@ img {
 
   .social-links {
     gap: var(--space-md);
+  }
+}
+
+@media (width < 420px) {
+  #navbar ul {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #navbar a {
+    font-size: 1.125rem;
+  }
+}
+
+@media (width < 320px) {
+  #navbar a {
+    font-size: 1rem;
+    padding: var(--space-xs);
   }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -37,10 +37,15 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --bg: oklch(10% 0.015 50);
     --text: oklch(96% 0.008 70);
   }
+}
+
+:root[data-theme="dark"] {
+  --bg: oklch(10% 0.015 50);
+  --text: oklch(96% 0.008 70);
 }
 
 /* ========================================
@@ -625,6 +630,63 @@ blockquote {
   }
 }
 
+#theme-switcher {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs) var(--space-sm);
+  margin-bottom: var(--space-md);
+  font-size: var(--font-size-sm);
+}
+
+.theme-switcher-label {
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+#theme-switcher button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  text-transform: lowercase;
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  transition: color 0.15s ease;
+
+  &::before,
+  &::after {
+    opacity: 0;
+    color: var(--accent);
+    transition: opacity 0.15s ease;
+  }
+
+  &::before {
+    content: "[";
+    margin-right: 2px;
+  }
+
+  &::after {
+    content: "]";
+    margin-left: 2px;
+  }
+
+  &:hover,
+  &[aria-pressed="true"] {
+    color: var(--accent);
+
+    &::before,
+    &::after {
+      opacity: 1;
+    }
+  }
+}
+
 /* ========================================
    Past Projects
    ======================================== */
@@ -773,15 +835,43 @@ img {
   }
 }
 
+@media (640px <= width < 820px) {
+  #navbar ul {
+    gap: var(--space-md);
+  }
+}
+
 @media (width < 640px) {
   .container {
     padding: var(--space-lg) var(--space-md);
   }
 
+  #navbar {
+    height: auto;
+    min-height: var(--nav-height);
+    padding: var(--space-sm) var(--space-md);
+  }
+
   #navbar ul {
-    gap: var(--space-sm);
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    column-gap: var(--space-xs);
+    row-gap: var(--space-xs);
+    width: 100%;
+  }
+
+  #navbar li {
+    display: flex;
     justify-content: center;
+  }
+
+  #navbar a {
+    padding: var(--space-xs) var(--space-sm);
+    text-align: center;
+  }
+
+  #footer {
+    padding: var(--space-lg) var(--space-md);
   }
 
   .social-links {


### PR DESCRIPTION
## Summary

- **Theme switcher** in the footer with `auto`/`light`/`dark` buttons backed by `localStorage`. A pre-paint inline script in `<head>` reads the stored preference before the stylesheet loads to prevent FOUC on dark-mode reload. The existing `@media (prefers-color-scheme: dark)` rule is gated to `:root:not([data-theme])` so OS preference wins by default but explicit user choice overrides it.
- **"Suggest a change"** link added inline to the footer credit line, pointing to the GitHub issue tracker.
- **Mobile/tablet/narrow-phone navbar polish**: switches from `flex-wrap` to a CSS grid with breakpoint-aware column counts so the 6 nav items lay out predictably across all phone sizes.
- **Cross-platform `pnpm build`**: dropped the Unix-only `mkdir -p` prefix from `build:css` since current `lightningcss-cli` (>=1.32) creates the output directory automatically. No new deps.
- Local Eleventy launch config switched from `npm` to `pnpm` to match the project's package manager (per CLAUDE.md).

## Why

Mobile users were seeing inconsistent spacing in the wrapped navbar; on very narrow phones (e.g. 344x882, Galaxy Fold–class viewports) the navbar's bracket pseudo-elements pushed `projects` past its 1fr cell and forced the entire page into horizontal overflow, breaking the footer too. The new layout tiers eliminate that overflow at every common phone width.

A theme switcher and a feedback link round out the polish: both are utility/meta affordances that pair naturally in the footer rather than crowding the navbar.

## Layout breakpoints

| Width | Navbar | Notes |
|---|---|---|
| ≥820px | Single row, `var(--space-lg)` gap | Desktop, unchanged |
| 640–819px | Single row, `var(--space-md)` gap | Tablet — fits without clipping |
| 420–639px | 3×2 grid (`repeat(3, 1fr)`) | Mid-mobile |
| 320–419px | 2×3 grid (`repeat(2, 1fr)`), 1.125rem font | Narrow phones — fixes the 344px regression |
| <320px | 2×3 grid, 1rem font, tighter padding | Galaxy Fold–class safeguard |

## Test plan

- [x] Theme switcher: click each of `auto`/`light`/`dark`; verify `data-theme` attribute and `localStorage.theme` update; reload to confirm persistence; click `auto` to confirm both clear and OS preference takes over.
- [x] Mobile navbar verified at 320, 344, 375, 414 (2-col), 480 (3-col), 768 (single row), 1280 (single row) — no horizontal overflow at any width.
- [x] Footer "Suggest a change" link points to `/issues/new`; theme switcher wraps gracefully on the narrowest viewports.
- [x] `pnpm build` succeeds end-to-end on Windows after the `mkdir -p` removal.
- [x] `pnpm lint` (markuplint) passes.
- [x] LightningCSS bundles+minifies cleanly (11.8KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)